### PR TITLE
Rename static variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,14 +134,14 @@ class TigerGraphConnection {
    * 
    * @param {Boolean} builtin 
    * @param {Boolean} dynamic 
-   * @param {Boolean} static 
+   * @param {Boolean} user_static 
    */
-  getEndpoints(builtin = true, dynamic = true, static = true) {
+  getEndpoints(builtin = true, dynamic = true, user_static = true) {
     return new Promise((resolve, reject) => {
         const options = {
             hostname: this.HOST,
             port: 9000,
-            path: `/endpoints?builtin=${builtin}&dynamic=${dynamic}&static=${static}`,
+            path: `/endpoints?builtin=${builtin}&dynamic=${dynamic}&static=${user_static}`,
             method: 'GET',
             headers: {
                 'Authorization': `Bearer ${this.TOKEN}`


### PR DESCRIPTION
Lib is failing with node **v11.15.0** because we are using a strict mode reserved word.

`/Users/marcos.conceicao/dev/marcos/Tigergraph.js/index.js:139
  getEndpoints(builtin = true, dynamic = true, static = true) {
                                                                          ^^^^^^

SyntaxError: Unexpected strict mode reserved word
    at Module._compile (internal/modules/cjs/loader.js:760:23)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:827:10)
    at Module.load (internal/modules/cjs/loader.js:685:32)
    at Function.Module._load (internal/modules/cjs/loader.js:620:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:877:12)
    at internal/main/run_main_module.js:21:11`

This PR renames `static` with `user_static`